### PR TITLE
Fix deprecated dynamic property in ClosureStream

### DIFF
--- a/src/ClosureStream.php
+++ b/src/ClosureStream.php
@@ -14,6 +14,8 @@ class ClosureStream
 {
     const STREAM_PROTO = 'closure';
 
+    public $context;
+
     protected static $isRegistered = false;
 
     protected $content;


### PR DESCRIPTION
Fixed deprecated creation of dynamic property Opis\Closure\ClosureStream::$context in PHP 8.2