### PR TITLE
Fixed SerializeInterface deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 Opis Closure
 ====================
-[![Tests](https://github.com/opis/closure/workflows/Tests/badge.svg)](https://github.com/opis/closure/actions)
-[![Latest Stable Version](https://poser.pugx.org/opis/closure/v/stable.png)](https://packagist.org/packages/opis/closure)
-[![Latest Unstable Version](https://poser.pugx.org/opis/closure/v/unstable.png)](https://packagist.org/packages/opis/closure)
-[![License](https://poser.pugx.org/opis/closure/license.png)](https://packagist.org/packages/opis/closure)
+[![Tests](https://github.com/charescape/serialize-closure/workflows/Tests/badge.svg)](https://github.com/charescape/serialize-closure/actions)
+[![Latest Stable Version](https://poser.pugx.org/charescape/serialize-closure/v/stable.png)](https://packagist.org/packages/charescape/serialize-closure)
+[![Latest Unstable Version](https://poser.pugx.org/charescape/serialize-closure/v/unstable.png)](https://packagist.org/packages/charescape/serialize-closure)
+[![License](https://poser.pugx.org/opis/closure/license.png)](https://packagist.org/packages/charescape/serialize-closure)
+
+# Differences compared to the original version
+
+- Installs as a replacement of [opis/closure](https://github.com/opis/closure) package, 
+uses the same namespaces and classes:
+  > composer remove opis/closure<br />
+  > composer require charescape/serialize-closure
+- Added support for PHP 8.0, 8.1, 8.2
+- Fixed deprecations:
+  - [PHP 8.1: Serializable interface deprecated](https://php.watch/versions/8.1/serializable-deprecated)
+    - In order to fix this, the `SerializableClosure` produces a different serialization format,
+      which is not compatible with the original `Opis\Closure\SerializableClosure` class. <br />
+      <b>If you have serialized closures in your database or files, you will need to re-serialize them.</b>
+  - [PHP 8.2: Dynamic Properties are deprecated](https://php.watch/versions/8.2/dynamic-properties-deprecated)
+
+___
 
 Serializable closures
 ---------------------

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
     },
     "require-dev": {
         "jeremeamia/superclosure": "^2.0",
-        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "ext-iconv": "*",
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,8 @@
 <phpunit bootstrap="./vendor/autoload.php" verbose="true">
+    <php>
+        <ini name="error_reporting" value="32767" />
+    </php>
+
     <testsuites>
         <testsuite name="Main">
             <file phpVersion="5.4.0" phpVersionOperator=">=">./tests/ClosureTest.php</file>
@@ -35,7 +39,7 @@
             <file phpVersion="7.4.0" phpVersionOperator=">=">./tests/NamespaceGroupTest.php</file>
         </testsuite>
         <testsuite name="ReflectionClosure6">
-            <file phpVersion="8.0.0-dev" phpVersionOperator=">=">./tests/ReflectionClosure6Test.php</file>
+            <file phpVersion="8.0.0" phpVersionOperator=">=">./tests/ReflectionClosure6Test.php</file>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -110,11 +110,9 @@ class SerializableClosure implements Serializable
     }
 
     /**
-     * Implementation of Serializable::serialize()
-     *
-     * @return  string  The serialized closure
+     * Implementation of Serializable::__serialize()
      */
-    public function serialize()
+    public function __serialize()
     {
         if ($this->scope === null) {
             $this->scope = new ClosureScope();
@@ -126,14 +124,14 @@ class SerializableClosure implements Serializable
         $scope = $object = null;
         $reflector = $this->getReflector();
 
-        if($reflector->isBindingRequired()){
+        if ($reflector->isBindingRequired()){
             $object = $reflector->getClosureThis();
             static::wrapClosures($object, $this->scope);
-            if($scope = $reflector->getClosureScopeClass()){
+            if ($scope = $reflector->getClosureScopeClass()) {
                 $scope = $scope->name;
             }
         } else {
-            if($scope = $reflector->getClosureScopeClass()){
+            if ($scope = $reflector->getClosureScopeClass()) {
                 $scope = $scope->name;
             }
         }
@@ -147,17 +145,17 @@ class SerializableClosure implements Serializable
 
         $this->mapByReference($use);
 
-        $ret = \serialize(array(
+        $ret = array(
             'use' => $use,
             'function' => $code,
             'scope' => $scope,
             'this' => $object,
             'self' => $this->reference,
-        ));
+        );
 
-        if (static::$securityProvider !== null) {
-            $data = static::$securityProvider->sign($ret);
-            $ret =  '@' . $data['hash'] . '.' . $data['closure'];
+        if (static::$securityProvider !== null && $this->scope->serializations === 1) {
+            $ser = \serialize($ret);
+            $ret = static::$securityProvider->sign($ser);
         }
 
         if (!--$this->scope->serializations && !--$this->scope->toserialize) {
@@ -165,6 +163,16 @@ class SerializableClosure implements Serializable
         }
 
         return $ret;
+    }
+
+    /**
+     * Implementation of Serializable::serialize()
+     *
+     * @return  string  The serialized closure
+     */
+    public function serialize()
+    {
+        return \serialize($this->__serialize());
     }
 
     /**
@@ -179,69 +187,45 @@ class SerializableClosure implements Serializable
     }
 
     /**
-     * Implementation of Serializable::unserialize()
-     *
-     * @param   string $data Serialized data
-     * @throws SecurityException
+     * Implementation of Serializable::__unserialize()
      */
-    public function unserialize($data)
+    public function __unserialize($data)
     {
         ClosureStream::register();
 
         if (static::$securityProvider !== null) {
-            if ($data[0] !== '@') {
+            if (!isset($data['hash'])) {
                 throw new SecurityException("The serialized closure is not signed. ".
                     "Make sure you use a security provider for both serialization and unserialization.");
             }
 
-            if ($data[1] !== '{') {
-                $separator = strpos($data, '.');
-                if ($separator === false) {
-                    throw new SecurityException('Invalid signed closure');
-                }
-                $hash = substr($data, 1, $separator - 1);
-                $closure = substr($data, $separator + 1);
-
-                $data = ['hash' => $hash, 'closure' => $closure];
-
-                unset($hash, $closure);
-            } else {
-                $data = json_decode(substr($data, 1), true);
+            if (!isset($data['closure']) || !is_string($data['closure'])) {
+                throw new SecurityException('Invalid signed closure');
             }
 
-            if (!is_array($data) || !static::$securityProvider->verify($data)) {
+            if (!static::$securityProvider->verify($data)) {
                 throw new SecurityException("Your serialized closure might have been modified and it's unsafe to be unserialized. " .
                     "Make sure you use the same security provider, with the same settings, " .
                     "both for serialization and unserialization.");
             }
 
-            $data = $data['closure'];
-        } elseif ($data[0] === '@') {
-            if ($data[1] !== '{') {
-                $separator = strpos($data, '.');
-                if ($separator === false) {
-                    throw new SecurityException('Invalid signed closure');
-                }
-                $hash = substr($data, 1, $separator - 1);
-                $closure = substr($data, $separator + 1);
-
-                $data = ['hash' => $hash, 'closure' => $closure];
-
-                unset($hash, $closure);
-            } else {
-                $data = json_decode(substr($data, 1), true);
-            }
-
-            if (!is_array($data) || !isset($data['closure']) || !isset($data['hash'])) {
+            $securityProvider = static::$securityProvider;
+            static::$securityProvider = null;
+            $data = \unserialize($data['closure']);
+            static::$securityProvider = $securityProvider;
+        } elseif (isset($data['hash']) || isset($data['closure'])) {
+            if (!isset($data['closure']) || !isset($data['hash'])) {
                 throw new SecurityException('Invalid signed closure');
             }
 
-            $data = $data['closure'];
+            if (!is_string($data['closure'])) {
+                throw new SecurityException('Invalid signed closure');
+            }
+
+            $data = \unserialize($data['closure']);
         }
 
-        $this->code = \unserialize($data);
-
-        // unset data
+        $this->code = $data;
         unset($data);
 
         $this->code['objects'] = array();
@@ -256,19 +240,30 @@ class SerializableClosure implements Serializable
 
         $this->closure = include(ClosureStream::STREAM_PROTO . '://' . $this->code['function']);
 
-        if($this->code['this'] === $this){
+        if ($this->code['this'] === $this){
             $this->code['this'] = null;
         }
 
         $this->closure = $this->closure->bindTo($this->code['this'], $this->code['scope']);
 
-        if(!empty($this->code['objects'])){
+        if (!empty($this->code['objects'])){
             foreach ($this->code['objects'] as $item){
                 $item['property']->setValue($item['instance'], $item['object']->getClosure());
             }
         }
 
         $this->code = $this->code['function'];
+    }
+
+    /**
+     * Implementation of Serializable::unserialize()
+     *
+     * @param   string $data Serialized data
+     * @throws SecurityException
+     */
+    public function unserialize($data)
+    {
+        $this->__unserialize(\unserialize($data));
     }
 
     /**

--- a/src/SerializableClosure.php
+++ b/src/SerializableClosure.php
@@ -383,7 +383,7 @@ class SerializableClosure implements Serializable
             unset($value);
             unset($data[self::ARRAY_RECURSIVE_KEY]);
         } elseif($data instanceof \stdClass){
-            if(isset($storage[$data])){
+            if(isset($storage[$data]) && $storage[$data] instanceof \stdClass){
                 $data = $storage[$data];
                 return;
             }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -206,11 +206,15 @@ class ClosureTest extends \PHPUnit\Framework\TestCase
         $t2->func = $f;
 
         $t->subtest = $t2;
+        $this->assertSame($t->func, $t->subtest->func);
 
+        SerializableClosure::enterContext();
         $x = unserialize(serialize($t));
+        SerializableClosure::exitContext();
 
-        $g = $x->func;
-        $g = $g();
+        $this->assertSame($x->func, $x->subtest->func);
+        $fun = $x->func;
+        $g = $fun();
 
         $ok = $x->func == $x->subtest->func;
         $ok = $ok && ($x->subtest->func == $g);
@@ -297,7 +301,6 @@ class ClosureTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('static protected called', $u());
     }
 
-
     public function testClosureStatic()
     {
         $f = static function(){};
@@ -358,26 +361,28 @@ class ObjnObj implements Serializable {
     public $subtest;
     public $func;
 
-    public function serialize() {
-
-        SerializableClosure::enterContext();
-
-        $object = serialize(array(
+    public function __serialize() {
+        $object = array(
             'subtest' => $this->subtest,
             'func' => SerializableClosure::from($this->func),
-        ));
-
-        SerializableClosure::exitContext();
+        );
 
         return $object;
     }
 
-    public function unserialize($data) {
-
-        $data = unserialize($data);
-
+    public function __unserialize($data) {
         $this->subtest = $data['subtest'];
         $this->func = $data['func']->getClosure();
+    }
+
+    public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    public function unserialize($data)
+    {
+        $this->__unserialize($data);
     }
 }
 

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -382,7 +382,7 @@ class ObjnObj implements Serializable {
 
     public function unserialize($data)
     {
-        $this->__unserialize($data);
+        $this->__unserialize(\unserialize($data));
     }
 }
 

--- a/tests/ReflectionClosureTest.php
+++ b/tests/ReflectionClosureTest.php
@@ -184,8 +184,8 @@ class ReflectionClosureTest extends \PHPUnit\Framework\TestCase
 
     public function testInterpolation1()
     {
-        $f1 = function() { return "${foo}${bar}{$foobar}"; };
-        $e1 = 'function() { return "${foo}${bar}{$foobar}"; }';
+        $f1 = function() { return "{$foo}{$bar}{$foobar}"; };
+        $e1 = 'function() { return "{$foo}{$bar}{$foobar}"; }';
 
         $this->assertEquals($e1, $this->c($f1));
     }


### PR DESCRIPTION
Replaces #10 

The main problem of the Serialization  deprecation is that once you have a magic method `__serialize()` implemented, the `Class::serialize()` method is never called upon `serialize` function call.

The return types of these methods are different: the magic method  `__serialize()` should return an associative array, that will be later packed into a string using default `\serialize()` function. Meanwhile, `Class::serialize()` method should return a string, that can be literally anything.

The original implementation of this library uses this feature in order to add a signature on top of the serialized function. Unfortunately, we cannot use this behavior anymore: see paragraph 1.

This pull request changes the way we work with the signed data.

I will review failed tests on older PHP versions tomorrow 